### PR TITLE
Fix code scanning alert no. 1: Application backup allowed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Fixes [https://github.com/cmput301f24-bugoff/can-do/security/code-scanning/1](https://github.com/cmput301f24-bugoff/can-do/security/code-scanning/1)

To fix the problem, we need to set the `android:allowBackup` attribute to `false` in the `application` element of the Android manifest file. This change will prevent the application from being automatically backed up, thereby reducing the risk of sensitive data being extracted by attackers.

- Locate the `application` element in the `app/src/main/AndroidManifest.xml` file.
- Change the value of the `android:allowBackup` attribute from `true` to `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
